### PR TITLE
very significant code dev. changes in lowneheim

### DIFF
--- a/B_Unification/lowenheim_proof.v
+++ b/B_Unification/lowenheim_proof.v
@@ -11,6 +11,7 @@
 
 Require Export lowenheim_formula.
 
+
 Require Import List.
 Import ListNotations.
 Require Export EqNat.
@@ -172,7 +173,9 @@ Proof.
   intros. simpl. left. intuition. 
 Qed.
 
-
+(** This is an intuitive lemma to prove that every element either belongs in any list
+or does not.
+*)
 Lemma var_in_out_list: forall (x : var) (lvar : list var),
   In x lvar \/ ~ In x lvar.
 Proof.
@@ -252,7 +255,8 @@ Proof.
 Qed.
 
 
-(** Lemma 10.4.5 from book X on page 254-255. This a very significant lemma used
+(** Lemma 10.4.5 from 'Term Rewriting and all that' book on page 254-255. 
+    This a very significant lemma used
     later for the proof that our Lownheim builder function (not the Main
     function, but the builder function), gives a unifier (not necessarily an
     mgu, which would be a next step of the proof). It states that if a term _t_
@@ -574,6 +578,9 @@ Qed.
     used in the proofs of intermediate lemmas that are in turn used in the final
     proof. *)
 
+
+(** *** General Utilities used in the final proof steps *)
+
 (** This is a function that converts a [option subst] to a [subst]. It is
     designed to be used mainly for [option subst]s that are [Some] $\sigma$. If
     the input [option subst] is not [Some] and is [None] then it returns the
@@ -719,6 +726,286 @@ Proof.
   intros. firstorder.
 Qed.
 
+(** The following five lemmas are also helper lemmas.
+
+*)
+
+Lemma None_not_Some {T U: Type} (f : U -> option T) (x: U):
+  (f x) = None -> (forall (t: T), ~ (f x) = Some t).
+Proof.
+  intros H1 H2 H3.
+  congruence.
+Qed.
+
+Lemma Some_not_None {T U: Type} (f : U -> option T) (x: U) (t: T):
+  (f x) = Some t -> ~ (f x = None).
+Proof.
+  intros H1 H2.
+  congruence.
+Qed.
+
+Lemma not_None_Some {T U: Type} (f : U -> option T) (x: U) :
+  ~ (f x = None) -> exists t : T, f x = Some t.
+Proof.
+  intros H.
+  destruct (f x) as [t | ].
+  - exists t; easy.
+  - congruence.
+Qed.
+
+Lemma not_Some_None {T U: Type} (f : U -> option T) (x: U) :
+ ( ~ exists t : T, f x = Some t) -> f x = None.
+Proof.
+  apply contrapositive_opposite.
+  intros H.
+  apply not_None_Some in H.
+  tauto.
+Qed.
+
+Lemma existsb_find {T: Type} (f: T -> bool) (l : list T) :
+  existsb f l = true ->
+  exists (a: T), find f l = Some a.
+Proof.
+  intros H.
+  apply NNPP.
+  intros H1.
+  apply not_Some_None in H1.   
+  assert (A1:= find_none f l).  
+  assert (A2:= A1 H1).
+  assert (A3:= existsb_exists f l).
+  destruct A3 as [A31 A32].
+  assert (A4:= A31 H).
+  destruct A4 as [t A41]. destruct A41 as [A411 A412].
+  assert (A21:= A2 t A411).
+  rewrite A412 in A21.
+  congruence.
+Qed.
+
+(** ***  Utilities used in the final proof case that [t] is unifiable
+
+*)
+
+
+(** In this section we are defining a number of functions and lemmas that are used in the proof
+ of the [unif_some_subst] lemma in the intermediate lemmas section that follows this utilities section.
+ We are focusing on connecting the concept of a '01' subtitution with any given substitution. 
+ We are attempting to create a '01' substitution given any input substitution, and then prove facts 
+ about the new '01' substitution.
+*)
+
+
+(** Function to build a [T0 subst], a subtitution that each variable is
+mapped to T0, given an input [lvar] list of variables
+*)
+Definition build_T0_subst (lvar : list var) : subst :=
+ map (fun v => (v, T0) ) lvar.
+
+(** Function to build a [T0 subst], given an input term t.
+*)
+Definition build_T0_subst_from_t (t : term) : subst :=
+ build_T0_subst (term_unique_vars t).
+
+
+(** With the four helper following functions, we are trying to create a final function that does 
+the following:
+  (1) given any substituion, it produces a '01' substitution building off the given substitution.
+  (2) it does that by composing two substitutions [s1] and [s1b] into a new one, [s2]. 
+  (3) It creates [s1b] from [s1]. [s1b] is a '01' substitution and so is [s2]. 
+*)
+
+
+(** Function to create the [s1b] '01' substitution, by mapping all the second parts
+  of each replacement of the substitution using the following rules : (1) all the variables of 
+  non-ground terms are mapped to [T0] and all ground terms are mapped to their simplified '01' version.
+  Therefore the substitution occuring from this function is a '01' subtitutition.
+*)
+Fixpoint make_unif_subst (tau : subst) : subst :=
+ match tau with
+ | [] => []
+ | (first , second) :: rest' => 
+              if (is_ground_term second) then 
+                (cons (first, simplify second)  (make_unif_subst rest')) 
+              else 
+                 (build_T0_subst_from_t second) ++ (make_unif_subst rest')
+              
+end.
+
+(** Function to augment create a list of [id] replacements, for all the variables of the 
+ [lvar] list input that are not in [lvar_s] list input. The [lvar_s] list input is supposedly the
+ list with the variables of a subtitution and we are trying eventually to augment the substitution
+ with and id subtitution.
+*)
+
+Fixpoint augment_with_id (lvar_s : list var) (lvar : list var) : subst :=
+  match lvar with
+  | [] => []
+  | v :: v' => 
+      if (var_set_includes_var v lvar_s) then (augment_with_id lvar_s v') 
+      else (v, VAR v) :: (augment_with_id lvar_s v')
+  end.
+
+(** Function to add the id substitution to the input subsitution.
+*)
+Definition add_id_subst (t : term) (tau : subst) : subst  :=
+  augment_with_id (subst_domain tau) (term_unique_vars t) ++ tau.
+
+
+(** This is the resulting function that given any subsitution for a term, produces
+ a '01' subsitution. Even though this function is not directly called by name, its implementation is directly used.
+ So whenever in the future comments there is a reference to a [convert_to_01_subst], what is meant is 
+ essentially the composition of the [make_unif_subst] substitution and the input subsitution [tau] - or
+ the resulting substitution [s2], by composing [s1] and [s1b]. 
+*)
+Definition convert_to_01_subst (tau : subst) (t : term) : subst :=
+ (subst_compose (make_unif_subst (add_id_subst t tau)) (add_id_subst t tau)).
+
+
+(** The following lemmas are about facts for the '01' subtitutions and our convert_to_01_subst function.
+ These lemmmas are very important for the intermediate lemmas section where in the 'unifiable t' case
+ we are trying to prove that when there exists any substitution for a term t, then there existis a
+ '01' substitution.
+*)
+
+
+
+(** Intuitive lemma that states adding an id subsitution to an existing unifier of a term, then we also get
+  another unifier. 
+*)
+
+Lemma add_id_unf :
+ forall (t : term) (sig1 : subst),
+  (unifier t sig1) ->
+  (unifier t (add_id_subst t sig1 )).
+Proof.
+intros. induction sig1.
+{
+  induction t.
+  {
+    unfold unifier in *. simpl in *. apply H.
+  }
+  {
+    unfold unifier in *. simpl in *. apply H.
+  }
+  {
+    unfold unifier in *. simpl in *. destruct PeanoNat.Nat.eqb. apply H. apply H.
+  }
+  {
+    unfold unifier in *. simpl in *. unfold add_id_subst. simpl.
+Admitted.
+
+
+(** Lemma that states two facts, given a term [t] and a unifier [sig1] of t: 
+    (1) the [convert_to_01_subst] substitution is also a unifier
+    (2) applying the [convert_to_01_subst] substitution on the term results in a term that is ground.
+*)
+
+Lemma unif_grnd_unif :
+ forall (t : term) (sig1 : subst),
+  (unifier t sig1) ->
+  (unifier t (subst_compose (make_unif_subst (add_id_subst t sig1)) (add_id_subst t sig1))) /\ 
+  (is_ground_term (apply_subst t (subst_compose (make_unif_subst (add_id_subst t sig1)) (add_id_subst t sig1)))) = true .
+Proof.
+ intros. split. 
+ -  unfold unifier. unfold unifier in H. rewrite subst_compose_eqv.
+    pose proof add_id_unf. specialize (H0 t sig1). unfold unifier in H0. specialize (H0 H). rewrite H0.
+ simpl. reflexivity.
+ -  admit.
+Admitted. 
+
+
+(*
+Lemma in_rec_is_01 :
+ forall (t : term) (sig : subst),
+ (In sig (all_01_substs (term_unique_vars t))) ->
+ (is_01_subst sig) = true.
+Proof.
+Admitted.
+*)
+
+(** If a subsitution [sig1] is a '01' substitution and the [domain] of the substitution is 
+   a subset of a list of variable [l1] then the substitution [sig1] is an element of all the 
+   '01' substitutions of that list [l1].  
+*)
+
+Lemma _01_in_all :
+ forall (l1 : list var) (sig : subst),
+  (is_01_subst sig) = true /\ sub_dmn_list l1 (subst_domain sig) ->
+  In sig (all_01_substs l1).
+Proof.
+intros. destruct H. unfold is_01_subst in H. 
+Admitted.
+
+(** Specialized format of the [_01_in_all] lemma. 
+   Instead of [l1] we havec[term_unique_vars t].
+*)
+
+Lemma _01_in_rec :
+  forall (t : term) (sig : subst),
+  (is_01_subst sig) = true /\ sub_dmn_list (term_unique_vars t) (subst_domain sig) ->
+  (In sig (all_01_substs (term_unique_vars t))).
+Proof.
+ intros. 
+ pose proof _01_in_all.
+ specialize (H0 (term_unique_vars t) sig).
+ apply H0. apply H.
+Qed.
+
+
+(** Lemma to show that given a unifier [sig1] of [t], then the
+ [convert_to_01_subst] subtitution is a '01' subst and also the variables of term [t] are 
+  a subset of the domain of the [convert_to_01_subst] substitution.
+*)
+
+Lemma make_unif_is_01 :
+ forall (t : term) (sig1 : subst),
+ (unifier t sig1) ->
+ (is_01_subst (subst_compose (make_unif_subst (add_id_subst t sig1)) (add_id_subst t sig1))) = true 
+ /\
+     sub_dmn_list (term_unique_vars t)
+       (subst_domain (subst_compose (make_unif_subst (add_id_subst t sig1)) (add_id_subst t sig1))).
+Proof.
+ intros. 
+Admitted.
+ 
+
+(** Lemma to show that given a unifier of term [t], then there exists a substitution [sig2]
+ that (1) belongs to all the '01' substitutions of term [t] and it also unifies [t], by making
+ [t] equal to T0 when applied on it (it is equal, not just equivalent because we want sig2 to be 
+ a ground substitution too. 
+
+*)
+
+Lemma unif_exists_grnd_unif :
+ forall (t : term) (sig1 : subst),
+  (unifier t sig1) ->
+
+  exists sig2 : subst,
+  In sig2 (all_01_substs (term_unique_vars t)) 
+  /\
+  match (update_term t sig2) with
+  | T0 => true
+  | _ => false
+  end = true.
+Proof.
+ intros. exists (subst_compose (make_unif_subst (add_id_subst t sig1)) (add_id_subst t sig1)) . split. 
+ -  pose proof _01_in_rec as H1. 
+   specialize (H1 t (subst_compose (make_unif_subst (add_id_subst t sig1)) (add_id_subst t sig1)) ). pose proof make_unif_is_01 as H2. specialize (H2 t sig1).
+   specialize (H2 H). (*specialize (H0 t (subst_compose (make_unif_subst (add_id_subst t sig1)) (add_id_subst t sig1)) ).*) specialize (H1 H2). apply H1.
+ - pose proof unif_grnd_unif. specialize (H0 t sig1 H). destruct H0. unfold unifier in H0.
+   unfold update_term. pose proof simplify_eqv.  specialize (H2 (apply_subst t (subst_compose (make_unif_subst (add_id_subst t sig1)) (add_id_subst t sig1)) ) ).
+    symmetry in H2. pose proof trans_compat2.  symmetry in H0. 
+    specialize (H3 T0 (apply_subst t (subst_compose (make_unif_subst (add_id_subst t sig1)) (add_id_subst t sig1)) ) 
+                ( simplify (apply_subst t (subst_compose (make_unif_subst (add_id_subst t sig1)) (add_id_subst t sig1)) ))).
+     specialize (H3 H0 H2). symmetry in H3.  pose proof simplify_eq_T0. 
+     specialize (H4 (apply_subst t (subst_compose (make_unif_subst (add_id_subst t sig1)) (add_id_subst t sig1)) )).
+     symmetry in H0.   rewrite H4. 
+      +   reflexivity.
+      + split.  { apply H0. }
+                { apply H1. } 
+Qed.
+
+
+
 
 (** ** Intermediate Lemmas *)
 
@@ -729,7 +1016,7 @@ Qed.
     substitution. *)
 
 
-(** *** [None] Substitution Case *)
+(** *** Not unifiable [t] case *)
 
 (** In this secton we prove intermediate lemmas useful for the second statement
     of the final proof: if a term is not unifiable, then [Lownheim_Main]
@@ -744,52 +1031,42 @@ Lemma some_subst_unifiable: forall (t : term),
   unifiable t.
 Proof.
   intros.
-  destruct H as [sig1 H1].
+  destruct H as [sig1 H1]. 
   induction t.
   - unfold unifiable. exists []. unfold unifier. simpl. reflexivity.
   - simpl in H1. inversion H1.
-  - unfold unifiable. exists sig1. unfold find_unifier in H1.
-    remember (update_term (VAR v) (rec_subst (VAR v)
-      (term_unique_vars (VAR v)) [])) in H1.
+  - unfold unifiable. exists sig1. unfold find_unifier in H1. apply find_some in H1. destruct H1. 
+    remember (update_term (VAR v) sig1) in H0.
     destruct t.
     + unfold update_term in Heqt. pose proof simplify_eqv.
-      specialize (H (apply_subst (VAR v) (rec_subst (VAR v)
-        (term_unique_vars (VAR v)) []))).
-      symmetry in Heqt. apply eq_some_eq_subst in H1.
-      rewrite H1 in H. rewrite H1 in Heqt.
-      rewrite Heqt in H. symmetry in H. apply H.
-    + simpl in H1. inversion H1.
-    + inversion H1.
-    + inversion H1.
-    + inversion H1.
-  - unfold unifiable. exists sig1. unfold find_unifier in H1.
-    remember (update_term (t1 + t2) (rec_subst (t1 + t2)
-      (term_unique_vars (t1 + t2)) [])) in H1.
+      specialize (H1 (apply_subst (VAR v) sig1) ). unfold unifier. symmetry in Heqt. 
+      rewrite Heqt in H1.  rewrite H1.  reflexivity. 
+    + inversion H0.
+    + inversion H0.
+    + inversion H0.
+    + inversion H0.
+  - unfold unifiable. exists sig1. unfold find_unifier in H1. apply find_some in H1. destruct H1. 
+    remember (update_term (t1 + t2) sig1) in H0.
     destruct t.
     + unfold update_term in Heqt. pose proof simplify_eqv.
-      specialize (H (apply_subst (t1 + t2) (rec_subst (t1 + t2)
-        (term_unique_vars (t1 + t2)) []))).
-      symmetry in Heqt. apply eq_some_eq_subst in H1.
-      rewrite H1 in H. rewrite H1 in Heqt.
-      rewrite Heqt in H. symmetry in H. apply H.
-    + inversion H1.
-    + inversion H1.
-    + inversion H1.
-    + inversion H1.
-  - unfold unifiable. exists sig1. unfold find_unifier in H1.
-    remember (update_term (t1 * t2) (rec_subst (t1 * t2)
-      (term_unique_vars (t1 * t2)) [])) in H1.
+      specialize (H1 (apply_subst (t1 + t2) sig1)).
+      symmetry in Heqt. unfold unifier. rewrite Heqt in H1. rewrite H1. 
+      reflexivity. 
+    + inversion H0.
+    + inversion H0.
+    + inversion H0.
+    + inversion H0.
+  - unfold unifiable. exists sig1. unfold find_unifier in H1. apply find_some in H1. destruct H1. 
+    remember (update_term (t1 * t2) sig1) in H0.
     destruct t.
     + unfold update_term in Heqt. pose proof simplify_eqv.
-      specialize (H (apply_subst (t1 * t2) (rec_subst (t1 * t2)
-        (term_unique_vars (t1 * t2)) []))).
-      symmetry in Heqt. apply eq_some_eq_subst in H1.
-      rewrite H1 in H. rewrite H1 in Heqt.
-      rewrite Heqt in H. symmetry in H. apply H.
-    + inversion H1.
-    + inversion H1.
-    + inversion H1.
-    + inversion H1.
+      specialize (H1 (apply_subst (t1 * t2) sig1)).
+      symmetry in Heqt. unfold unifier. rewrite Heqt in H1. rewrite H1. 
+      reflexivity. 
+    + inversion H0.
+    + inversion H0.
+    + inversion H0.
+    + inversion H0.
 Qed.
 
 
@@ -807,7 +1084,7 @@ Proof.
 Qed.
 
 
-(* Lemma to show that if a term _t_ is not unifiable, the [find_unifier]
+(** Lemma to show that if a term _t_ is not unifiable, the [find_unifier]
     function returns [None] with _t_ as input. *)
 
 Lemma not_unifiable_find_unifier_none_subst : forall (t : term),
@@ -825,7 +1102,7 @@ Proof.
 Qed.
 
 
-(** *** [Some] Substituion Case *)
+(** *** Unifiable [t] Case *)
 
 (** In this secton we prove intermediate lemmas useful for the first statement
     of the final proof: if a term is unifiable, then [Lowenheim_Main] function
@@ -837,63 +1114,75 @@ Qed.
 Lemma Some_subst_unifiable : forall (t : term) (sig : subst),
   find_unifier t = Some sig -> unifier t sig.
 Proof.
-  intros.
+  intros. unfold find_unifier in H. 
   induction t.
   - simpl in H. apply eq_some_eq_subst in H. symmetry in H. rewrite H.
     unfold unifier. simpl. reflexivity.
   - simpl in H. inversion H.
-  - unfold find_unifier in H. remember (update_term (VAR v)
-      (rec_subst (VAR v) (term_unique_vars (VAR v)) [])) in H.
+  - unfold find_unifier in H.  apply find_some in H. destruct H. 
+    remember (update_term (VAR v) sig) in H0.
     destruct t.
-    + unfold update_term in Heqt. pose proof simplify_eqv.
-      specialize (H0 (apply_subst (VAR v) (rec_subst (VAR v)
-        (term_unique_vars (VAR v)) []))).
-      symmetry in Heqt. apply eq_some_eq_subst in H.
-      rewrite H in H0. rewrite H in Heqt.
-      rewrite Heqt in H0. symmetry in H0. apply H0.
-    + inversion H.
-    + inversion H.
-    + inversion H.
-    + inversion H.
-  - unfold find_unifier in H. remember (update_term (t1 + t2)
-      (rec_subst (t1 + t2) (term_unique_vars (t1 + t2)) [])) in H.
+    + unfold unifier. unfold update_term in Heqt. pose proof simplify_eqv.
+      specialize (H1 (apply_subst (VAR v) sig) ). symmetry in Heqt. 
+      rewrite Heqt in H1.  rewrite H1.  reflexivity.
+    + inversion H0.
+    + inversion H0.
+    + inversion H0.
+    + inversion H0.
+  - unfold find_unifier in H.   apply find_some in H. destruct H. 
+    remember (update_term (t1 + t2) sig) in H0.
     destruct t.
-    + unfold update_term in Heqt. pose proof simplify_eqv.
-      specialize (H0 (apply_subst (t1 + t2) (rec_subst (t1 + t2)
-        (term_unique_vars (t1 + t2)) []))).
-      symmetry in Heqt. apply eq_some_eq_subst in H.
-      rewrite H in H0. rewrite H in Heqt.
-      rewrite Heqt in H0. symmetry in H0. apply H0.
-    + inversion H.
-    + inversion H.
-    + inversion H.
-    + inversion H.
-  - unfold find_unifier in H. remember (update_term (t1 * t2)
-      (rec_subst (t1 * t2) (term_unique_vars (t1 * t2)) [])) in H.
+    + unfold unifier. unfold update_term in Heqt. pose proof simplify_eqv.
+      specialize (H1 (apply_subst (t1 + t2) sig) ). symmetry in Heqt. 
+      rewrite Heqt in H1.  rewrite H1.  reflexivity.
+    + inversion H0.
+    + inversion H0.
+    + inversion H0.
+    + inversion H0.
+  - unfold find_unifier in H.   apply find_some in H. destruct H. 
+    remember (update_term (t1 * t2) sig) in H0.
     destruct t.
-    + unfold update_term in Heqt. pose proof simplify_eqv.
-      specialize (H0 (apply_subst (t1 * t2) (rec_subst (t1 * t2)
-        (term_unique_vars (t1 * t2)) []))).
-      symmetry in Heqt. apply eq_some_eq_subst in H.
-      rewrite H in H0. rewrite H in Heqt.
-      rewrite Heqt in H0. symmetry in H0. apply H0.
-    + inversion H.
-    + inversion H.
-    + inversion H.
-    + inversion H.
+    + unfold unifier. unfold update_term in Heqt. pose proof simplify_eqv.
+      specialize (H1 (apply_subst (t1 * t2) sig) ). symmetry in Heqt. 
+      rewrite Heqt in H1.  rewrite H1.  reflexivity.
+    + inversion H0.
+    + inversion H0.
+    + inversion H0.
+    + inversion H0.
 Qed.
+ 
 
 
-(** This lemma shows that if there is a unifier, then there is a "ground
-    unifier". *)
+
+(** This lemma is the one using all the utilities defined in the utilities section for the 
+   'unifiable t' case. It states that if there is a unifier [sig1] for term _t_ then there exists
+   some substitution [sig2] for which the find_unifier function returns [Some] [sig2].
+   Here is the main outline of the proof : As done in the utilities section, given any unifier 
+   [sig1] of a term _t_, we can find a '01' unifier. Since our [find_unifier] function also finds 
+   a '01' unifier by going through the list of available '01' unifier, there must exist a '01' unifier
+   [sig2] returned by our [find_unifier] function under the [Some] wrapper.  
+*)                   
 
 Lemma unif_some_subst : forall (t: term),
   (exists sig1, unifier t sig1) ->
   exists sig2, find_unifier t = Some sig2.
 Proof.
-  intros.
-  destruct H as [sig1 H].
-Admitted.
+  intros t H. induction t.
+   - simpl. exists []. reflexivity. 
+   - simpl. destruct H. unfold unifier in H. simpl in H. apply T1_not_equiv_T0 in H. inversion H. 
+   - unfold find_unifier.    
+    apply existsb_find.
+    apply existsb_exists. destruct H. pose proof unif_exists_grnd_unif. specialize (H0 (VAR v) x). 
+    apply H0.  apply H. 
+  - unfold find_unifier.    
+    apply existsb_find.
+    apply existsb_exists. destruct H. pose proof unif_exists_grnd_unif. specialize (H0 (t1 + t2) x). 
+    apply H0.  apply H. 
+  - unfold find_unifier.    
+    apply existsb_find.
+    apply existsb_exists. destruct H. pose proof unif_exists_grnd_unif. specialize (H0 (t1 * t2) x). 
+    apply H0.  apply H. 
+Qed.
 
 
 (** Lemma to show that if no substituion makes [find_unifier] return
@@ -986,7 +1275,9 @@ Proof.
 Qed.
 
 
-(** This the final top-level lemma that encapsulates all our efforts so far. It
+
+
+(** This is the final top-level lemma that encapsulates all our efforts so far. It
     proves the two main statements required for the final proof. The two
     statements, as phrased in the beginning of the chapter are: 1) if a term is
     unifiable, then our own defined [Lowenheim_Main] function produces a most


### PR DESCRIPTION
> completely replaced the find_unifier function in formula.v by making it go through all the '01' substitutions instead of
finding just a single one recursively 
> fixed all the broken proofs in lowenheim_proof.v resulting from the above change
> broke down the final admitted lemma into 4 lower-level new admitted lemmas dealing with '01' substitutions